### PR TITLE
Makes get_rays.cpp support opencv2 

### DIFF
--- a/src/get_rays.cpp
+++ b/src/get_rays.cpp
@@ -118,8 +118,8 @@ void saliency_map_callback(const sensor_msgs::ImageConstPtr& msg) {
 }
 
 cv::Ptr<cv::SimpleBlobDetector> createSimpleBlobDetector(const cv::SimpleBlobDetector::Params &params) {
-#if CV_MAJOR_VERSION < 3   // If you are using OpenCV 2
   using namespace cv;
+#if CV_MAJOR_VERSION < 3   // If you are using OpenCV 2
   SimpleBlobDetector *detector = new SimpleBlobDetector(params);
   return Ptr<SimpleBlobDetector>(detector);
 #else

--- a/src/get_rays.cpp
+++ b/src/get_rays.cpp
@@ -117,6 +117,16 @@ void saliency_map_callback(const sensor_msgs::ImageConstPtr& msg) {
   }
 }
 
+cv::Ptr<cv::SimpleBlobDetector> createSimpleBlobDetector(const cv::SimpleBlobDetector::Params &params) {
+#if CV_MAJOR_VERSION < 3   // If you are using OpenCV 2
+  using namespace cv;
+  SimpleBlobDetector *detector = new SimpleBlobDetector(params);
+  return Ptr<SimpleBlobDetector>(detector);
+#else
+  return SimpleBlobDetector::create(params);
+#endif
+}
+
 int main(int argc, char **argv) {
   // initialize blob detector
   cv::SimpleBlobDetector::Params params;
@@ -130,7 +140,7 @@ int main(int argc, char **argv) {
   params.filterByCircularity = false;
   params.filterByArea = true;
   params.minArea = 50;
-  detector = cv::SimpleBlobDetector::create(params);
+  detector = createSimpleBlobDetector(params);
 
   // initialize joint command
   joint_cmd.name.resize(2);


### PR DESCRIPTION
This commit addresses a compilation issue encountered on Ubuntu 14.04, while using opencv2 shipped with ros-indigo. Indeed, cv::SimpleBlobDetector::create doesn't exist in opencv2, see https://docs.opencv.org/2.4/modules/features2d/doc/common_interfaces_of_feature_detectors.html.

**I tested this commit on Ubuntu 14.04 using opencv2 ONLY.**

The error I used to have is the following:

```
[100%] Built target gazebo_ros_multicamera
/home/lguyot/Documents/NRP/GazeboRosPackages/src/embodied_attention/src/get_rays.cpp: In function ‘int main(int, char**)’:
/home/lguyot/Documents/NRP/GazeboRosPackages/src/embodied_attention/src/get_rays.cpp:133:51: error: no matching function for call to ‘cv::SimpleBlobDetector::create(cv::SimpleBlobDetector::Params&)’
   detector = cv::SimpleBlobDetector::create(params);
                                                   ^
/home/lguyot/Documents/NRP/GazeboRosPackages/src/embodied_attention/src/get_rays.cpp:133:51: note: candidate is:
In file included from /home/lguyot/Documents/NRP/GazeboRosPackages/src/embodied_attention/src/get_rays.cpp:6:0:
/usr/include/opencv2/features2d/features2d.hpp:182:41: note: static cv::Ptr<cv::FeatureDetector> cv::FeatureDetector::create(const string&)
     CV_WRAP static Ptr<FeatureDetector> create( const string& detectorType );
                                         ^
/usr/include/opencv2/features2d/features2d.hpp:182:41: note:   no known conversion for argument 1 from ‘cv::SimpleBlobDetector::Params’ to ‘const string& {aka const std::basic_string<char>&}’
make[2]: *** [embodied_attention/CMakeFiles/get_rays.dir/src/get_rays.cpp.o] Error 1
make[1]: *** [embodied_attention/CMakeFiles/get_rays.dir/all] Error 2
make: *** [all] Error 2
Invoking "make -j4" failed
```
